### PR TITLE
Add LocalStack license requirement and standardize setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -39,7 +39,7 @@ jobs:
 
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           DNS_ADDRESS: 0
         run: |
           pip install localstack awscli-local[ver1]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,29 @@
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION=us-east-1
+SHELL := /bin/bash
+
+usage:		## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$//' | sed -e 's/##//'
+
+install:	## Install dependencies
+	@which localstack || pip install localstack
+	@which awslocal || pip install awscli-local
+
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+
+stop:		## Stop LocalStack
+	@localstack stop
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
+
 all: backend frontend-build
 
 TEMPLATES = auth product-mock shoppingcart-service
@@ -44,4 +70,4 @@ frontend-serve:
 frontend-build: 
 	$(MAKE) -C frontend build
 
-.PHONY: all backend backend-delete backend-tests create-bucket amplify-deploy frontend-serve frontend-build
+.PHONY: usage install start stop ready logs all backend backend-delete backend-tests create-bucket amplify-deploy frontend-serve frontend-build

--- a/README.md
+++ b/README.md
@@ -30,17 +30,27 @@ The products in an anonymous cart are terminated after some time, while an authe
 | `/product`                 | `GET`  | Retrieve details for all products.                                                                                              |
 | `/product/{product_id}`    | `GET`  | Retrieve details for a single product.                                                                                          |
 
-## Instructions
+## Prerequisites
 
-- LocalStack Pro with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [Serverless Application Model](https://docs.localstack.cloud/user-guide/integrations/aws-sam/) with the [`samlocal`](https://github.com/localstack/aws-sam-cli-local) installed.
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
 - [Node.js](https://nodejs.org/en/download/) with [`yarn`](https://yarnpkg.com/getting-started/install) installed.
 - [Python 3.8.0](https://www.python.org/downloads/release/python-380/) in the `PATH`
 - [LocalSurf](https://docs.localstack.cloud/user-guide/tools/localsurf/) to repoint AWS service calls to LocalStack in the web app.
 
+## Start LocalStack
 
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+
+```shell
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
+make start
+make ready
+```
+
+Alternatively, you can start LocalStack directly with the extra CORS configuration required by this application:
 
 ```shell
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>


### PR DESCRIPTION
## Summary

- Add license requirement bullet to Prerequisites section in README
- Add `start`, `stop`, `ready`, `logs`, `usage`, `install` targets to Makefile with auth guard
- Update README to use `make start` / `make ready` pattern
- Upgrade `actions/checkout` to v4
- Replace `LOCALSTACK_API_KEY` with `LOCALSTACK_AUTH_TOKEN` in workflow
